### PR TITLE
adaptive matching, pt-BR support, failed highlights view, manual book selection

### DIFF
--- a/components/StatusPopup.lua
+++ b/components/StatusPopup.lua
@@ -1,6 +1,7 @@
 local UIManager = require("ui/uimanager")
 local Popup = require("components.Popup")
 local useCloseButton = require("composables/useCloseButton")
+local FailedTargetsView = require("views.FailedTargets")
 
 
 return function(content, ctx)
@@ -20,6 +21,27 @@ return function(content, ctx)
                 useCloseButton(ctx)
             end,
         })
+    end
+
+    -- When finished with failures, offer a "View failed" button
+    if ctx.finished and ctx.targets then
+        local failed = {}
+        for _, t in ipairs(ctx.targets) do
+            if t.status == "failed" then
+                failed[#failed + 1] = t
+            end
+        end
+        if #failed > 0 then
+            table.insert(buttons, 1, {
+                text = string.format("View failed (%d)", #failed),
+                callback = function()
+                    useCloseButton(ctx)
+                    UIManager:nextTick(function()
+                        FailedTargetsView(failed)
+                    end)
+                end,
+            })
+        end
     end
 
     local popup = Popup("Import status", content, buttons)

--- a/main.lua
+++ b/main.lua
@@ -25,7 +25,7 @@ function HighlightImport:init()
     self.parser = MyClipping:new{ ui = self.ui }
     self.file_path = G_reader_settings:readSetting("highlight_import_file_path") or ""
     self.last_path = G_reader_settings:readSetting("highlight_import_last_path") or ""
-    self.algorithm = G_reader_settings:readSetting("highlight_import_matching_algorithm") or "fuzzy"
+    self.algorithm = G_reader_settings:readSetting("highlight_import_matching_algorithm") or "adaptive"
 end
 
 function HighlightImport:onReaderReady()

--- a/services/MatchingStrategies/adaptive.lua
+++ b/services/MatchingStrategies/adaptive.lua
@@ -49,6 +49,23 @@ return function (instance)
     log(string.format("Starting import. Targets: %d, Existing highlights: %d",
         #instance.targets, n_existing))
 
+    -- Truncate a string safely at a UTF-8 character boundary.
+    -- Lua's string.sub works on bytes, which can split multi-byte characters
+    -- (e.g. "á" = 2 bytes, "—" = 3 bytes), producing invalid UTF-8 that the
+    -- search engine silently fails to match.
+    local function utf8_sub(s, max_bytes)
+        if #s <= max_bytes then return s end
+        local i = max_bytes
+        -- Walk back until we are at the start of a UTF-8 character.
+        -- Continuation bytes have the form 10xxxxxx (0x80–0xBF).
+        while i > 0 and s:byte(i) >= 0x80 and s:byte(i) <= 0xBF do
+            i = i - 1
+        end
+        -- Also skip the leading byte of a multi-byte sequence if it would be orphaned.
+        if i > 0 and s:byte(i) >= 0x80 then i = i - 1 end
+        return s:sub(1, i)
+    end
+
     -- Normalize curly/smart typography to ASCII equivalents.
     -- Used as a fallback when the exact text fails to match, which happens when
     -- the Kindle edition used smart quotes/dashes but the EPUB uses plain ASCII.
@@ -62,6 +79,22 @@ return function (instance)
         s = s:gsub("\xe2\x80\xa6", "...") -- U+2026 ellipsis
         s = s:gsub("%s%s+", " ")          -- collapse double-spaces left by "word – word" → "word  -  word"
         return s
+    end
+
+    -- Remove em/en-dashes and surrounding spaces used for dialogue attribution.
+    -- Portuguese Kindle books use " — Palavra" (space + em-dash + space) at the
+    -- start of dialogue lines. Some EPUB editions represent the same text differently.
+    -- This produces a version with dashes stripped so the search can find the
+    -- underlying prose without the typographic dash character.
+    local function strip_dashes(s)
+        -- Remove leading "— " or "– " patterns (dialogue openers)
+        s = s:gsub("^\xe2\x80\x94%s*", "")  -- leading em-dash + optional space
+        s = s:gsub("^\xe2\x80\x93%s*", "")  -- leading en-dash + optional space
+        -- Remove inline " — " and " – " patterns
+        s = s:gsub("%s*\xe2\x80\x94%s*", " ")
+        s = s:gsub("%s*\xe2\x80\x93%s*", " ")
+        s = s:gsub("%s+", " ")
+        return s:match("^%s*(.-)%s*$") or s
     end
 
     instance.cancel_import = false
@@ -118,8 +151,10 @@ return function (instance)
             instance.ui.paging:gotoPage(tonumber(target.page))
         end
 
-        -- Truncate very long highlights to avoid search engine memory pressure
-        local query = #target.annotation > 150 and target.annotation:sub(1, 150) or target.annotation
+        -- Truncate very long highlights to avoid search engine memory pressure.
+        -- Use utf8_sub to avoid splitting multi-byte characters (á, ã, ê, —, etc.)
+        -- which would produce invalid UTF-8 that the search engine silently rejects.
+        local query = utf8_sub(target.annotation, 150)
         log(string.format("[SEARCH p.%s] %s", tostring(target.page), query))
         local res = search:searchFromCurrent(query, 0, false, true)
 
@@ -139,9 +174,10 @@ return function (instance)
         if not res or #res == 0 then
             local base = query_norm  -- already normalized; same as query if no special chars
             for _, len in ipairs({ 80, 50 }) do
-                if #base > len then
+                local prefix = utf8_sub(base, len)
+                if #prefix < #base then
                     log(string.format("[RETRY prefix-%d]", len))
-                    res = search:searchFromCurrent(base:sub(1, len), 0, false, true)
+                    res = search:searchFromCurrent(prefix, 0, false, true)
                     if res and #res > 0 then break end
                 end
             end
@@ -156,11 +192,182 @@ return function (instance)
             log("[RETRY backward]")
             local base = query_norm
             res = search:searchFromCurrent(base, 1, false, true)
-            if (not res or #res == 0) and #base > 80 then
-                res = search:searchFromCurrent(base:sub(1, 80), 1, false, true)
+            if not res or #res == 0 then
+                local p80 = utf8_sub(base, 80)
+                if #p80 < #base then
+                    res = search:searchFromCurrent(p80, 1, false, true)
+                end
             end
-            if (not res or #res == 0) and #base > 50 then
-                res = search:searchFromCurrent(base:sub(1, 50), 1, false, true)
+            if not res or #res == 0 then
+                local p50 = utf8_sub(base, 50)
+                if #p50 < #base then
+                    res = search:searchFromCurrent(p50, 1, false, true)
+                end
+            end
+        end
+
+        -- Fallback: strip em/en-dashes and retry.
+        -- Dialogue lines in Portuguese Kindle books often start with "— Palavra"
+        -- (U+2014 + space). Some EPUB editions omit the dash entirely or use a
+        -- different encoding, causing all dash-containing highlights to fail.
+        if not res or #res == 0 then
+            local stripped = strip_dashes(query_norm)
+            if stripped ~= query_norm and #stripped >= 10 then
+                log("[RETRY strip-dashes]")
+                res = search:searchFromCurrent(stripped, 0, false, true)
+                if not res or #res == 0 then
+                    local p80 = utf8_sub(stripped, 80)
+                    if #p80 < #stripped then res = search:searchFromCurrent(p80, 0, false, true) end
+                end
+                if not res or #res == 0 then
+                    local p50 = utf8_sub(stripped, 50)
+                    if #p50 < #stripped then res = search:searchFromCurrent(p50, 0, false, true) end
+                end
+                -- Also try backward
+                if not res or #res == 0 then
+                    res = search:searchFromCurrent(stripped, 1, false, true)
+                end
+            end
+        end
+
+        -- Fallback: try the text segment at/after the first em/en-dash.
+        -- Kindle clippings sometimes capture text from the end of one paragraph
+        -- joined to the start of the next (e.g. "claro. — Então às cinco").
+        -- The EPUB has these as separate paragraphs: the second paragraph often
+        -- STARTS with the dash ("— Então às cinco"), so we must search for the
+        -- dash-inclusive version AND the dash-stripped version.
+        if not res or #res == 0 then
+            local raw_dash_pos = query:find("\xe2\x80\x94", 1, true)
+                              or query:find("\xe2\x80\x93", 1, true)
+            if raw_dash_pos then
+                -- 1) Include the dash: "— Então às cinco, e de sobrecasaca."
+                --    This matches EPUBs where the paragraph starts with the dash.
+                local with_dash = query:sub(raw_dash_pos):match("^%s*(.-)%s*$")
+                -- 2) Exclude the dash (skip the 3-byte sequence + space)
+                local after_raw = query:sub(raw_dash_pos + 3):match("^%s*(.-)%s*$")
+                for _, probe in ipairs({ with_dash, after_raw }) do
+                    if probe and #probe >= 10 and (not res or #res == 0) then
+                        log(string.format("[RETRY around-dash] %s", utf8_sub(probe, 60)))
+                        res = search:searchFromCurrent(probe, 0, false, true)
+                        if not res or #res == 0 then
+                            res = search:searchFromCurrent(probe, 1, false, true)
+                        end
+                        -- also try shorter prefix of this probe
+                        if not res or #res == 0 then
+                            local p80 = utf8_sub(probe, 80)
+                            if #p80 < #probe then
+                                res = search:searchFromCurrent(p80, 0, false, true)
+                                if not res or #res == 0 then
+                                    res = search:searchFromCurrent(p80, 1, false, true)
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+            -- Also try via the normalized form (dash replaced with " - ")
+            if not res or #res == 0 then
+                local dash_start = query_norm:find(" - ", 1, true)
+                if dash_start then
+                    -- normalized "- " prefix version
+                    local with_dash_norm = query_norm:sub(dash_start + 1):match("^%s*(.-)%s*$")
+                    local after_dash_norm = query_norm:sub(dash_start + 3):match("^%s*(.-)%s*$")
+                    for _, probe in ipairs({ with_dash_norm, after_dash_norm }) do
+                        if probe and #probe >= 10 and (not res or #res == 0) then
+                            log(string.format("[RETRY norm-dash] %s", utf8_sub(probe, 60)))
+                            res = search:searchFromCurrent(probe, 0, false, true)
+                            if not res or #res == 0 then
+                                res = search:searchFromCurrent(probe, 1, false, true)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        -- Fallback: split annotation by newline and try each line independently.
+        -- The Kindle stores multi-paragraph selections joined with literal \n characters.
+        -- KOReader's search engine works within individual EPUB paragraph elements, so
+        -- a query containing \n will NEVER match across paragraphs.
+        -- Strategy: try each non-empty line as a standalone query (forward + backward).
+        -- This is the primary fix for cross-paragraph highlights like:
+        --   "claro.\n— Então às cinco, e de sobrecasaca."
+        -- where "claro." is one paragraph and "— Então às cinco..." is another.
+        if (not res or #res == 0) and target.annotation:find("\n", 1, true) then
+            local lines_list = {}
+            for ln in (target.annotation .. "\n"):gmatch("([^\n]*)\n") do
+                ln = ln:match("^%s*(.-)%s*$") or ""
+                if #ln >= 15 then
+                    lines_list[#lines_list + 1] = ln
+                end
+            end
+            for _, ln in ipairs(lines_list) do
+                if not res or #res == 0 then
+                    local ln_norm = normalize_typography(ln)
+                    log(string.format("[RETRY newline-split] %s", utf8_sub(ln_norm, 60)))
+                    res = search:searchFromCurrent(ln_norm, 0, false, true)
+                    if not res or #res == 0 then
+                        res = search:searchFromCurrent(ln_norm, 1, false, true)
+                    end
+                    -- also try shorter prefixes of this line
+                    if not res or #res == 0 then
+                        local p80 = utf8_sub(ln_norm, 80)
+                        if #p80 < #ln_norm then
+                            res = search:searchFromCurrent(p80, 0, false, true)
+                            if not res or #res == 0 then
+                                res = search:searchFromCurrent(p80, 1, false, true)
+                            end
+                        end
+                    end
+                    if not res or #res == 0 then
+                        local p50 = utf8_sub(ln_norm, 50)
+                        if #p50 < #ln_norm then
+                            res = search:searchFromCurrent(p50, 0, false, true)
+                            if not res or #res == 0 then
+                                res = search:searchFromCurrent(p50, 1, false, true)
+                            end
+                        end
+                    end
+                    -- also try strip-dashes variant of this line
+                    if not res or #res == 0 then
+                        local ln_stripped = strip_dashes(ln_norm)
+                        if ln_stripped ~= ln_norm and #ln_stripped >= 10 then
+                            res = search:searchFromCurrent(ln_stripped, 0, false, true)
+                            if not res or #res == 0 then
+                                res = search:searchFromCurrent(ln_stripped, 1, false, true)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        -- Fallback: short prefix (first ~40 bytes) to handle cross-paragraph clippings.
+        -- The Kindle records multi-paragraph selections as a single joined string.
+        -- The KOReader search engine operates within individual EPUB paragraph elements,
+        -- so a string that spans two paragraphs will NEVER match as a whole.
+        -- Searching for only the first portion (which lives entirely in the first paragraph)
+        -- works around this fundamental limitation.
+        -- This fires regardless of whether dashes are involved.
+        if not res or #res == 0 then
+            -- First try: everything before the first sentence-ending punctuation
+            -- followed by a space (captures "claro." from "claro. — Então...").
+            local first_sentence = query_norm:match("^(.+[%.!%?])[%s%-]") or
+                                   query_norm:match("^(.+[%.!%?])$")
+            if first_sentence then
+                first_sentence = first_sentence:match("^%s*(.-)%s*$") or first_sentence
+            end
+            -- Fallback: take the first 40 UTF-8-safe bytes as the prefix
+            local short_prefix = utf8_sub(query_norm, 40)
+            -- Use the shorter of the two as long as it's meaningful (≥ 10 chars)
+            for _, probe in ipairs({ first_sentence, short_prefix }) do
+                if probe and #probe >= 10 and (not res or #res == 0) then
+                    log(string.format("[RETRY short-prefix] %s", probe))
+                    res = search:searchFromCurrent(probe, 0, false, true)
+                    if not res or #res == 0 then
+                        res = search:searchFromCurrent(probe, 1, false, true)
+                    end
+                end
             end
         end
 
@@ -176,11 +383,13 @@ return function (instance)
                 if inner and #inner >= 20 then
                     log("[RETRY no-outer-quote]")
                     res = search:searchFromCurrent(inner, 0, false, true)
-                    if (not res or #res == 0) and #inner > 80 then
-                        res = search:searchFromCurrent(inner:sub(1, 80), 0, false, true)
+                    if not res or #res == 0 then
+                        local p80 = utf8_sub(inner, 80)
+                        if #p80 < #inner then res = search:searchFromCurrent(p80, 0, false, true) end
                     end
-                    if (not res or #res == 0) and #inner > 50 then
-                        res = search:searchFromCurrent(inner:sub(1, 50), 0, false, true)
+                    if not res or #res == 0 then
+                        local p50 = utf8_sub(inner, 50)
+                        if #p50 < #inner then res = search:searchFromCurrent(p50, 0, false, true) end
                     end
                 end
             end

--- a/services/MyClipping.lua
+++ b/services/MyClipping.lua
@@ -36,9 +36,46 @@ end
 --      }
 -- }
 
--- Normalize a title for matching: lowercase, strip trailing (...) and " - ..."
+-- Map UTF-8 multi-byte sequences for accented Latin characters to their ASCII base.
+-- Lua's string.lower/upper are ASCII-only, so accented chars must be stripped manually
+-- to allow title matching across sources with different diacritic conventions
+-- (e.g. Kindle "Kariênina" vs filename "Karienina").
+local accent_map = {
+    -- 2-byte sequences (U+00C0–U+00FF range)
+    ["\xc3\x80"] = "a", ["\xc3\x81"] = "a", ["\xc3\x82"] = "a", ["\xc3\x83"] = "a",
+    ["\xc3\x84"] = "a", ["\xc3\x85"] = "a", ["\xc3\x86"] = "ae",
+    ["\xc3\x87"] = "c",
+    ["\xc3\x88"] = "e", ["\xc3\x89"] = "e", ["\xc3\x8a"] = "e", ["\xc3\x8b"] = "e",
+    ["\xc3\x8c"] = "i", ["\xc3\x8d"] = "i", ["\xc3\x8e"] = "i", ["\xc3\x8f"] = "i",
+    ["\xc3\x91"] = "n",
+    ["\xc3\x92"] = "o", ["\xc3\x93"] = "o", ["\xc3\x94"] = "o", ["\xc3\x95"] = "o",
+    ["\xc3\x96"] = "o",
+    ["\xc3\x99"] = "u", ["\xc3\x9a"] = "u", ["\xc3\x9b"] = "u", ["\xc3\x9c"] = "u",
+    ["\xc3\x9d"] = "y",
+    ["\xc3\xa0"] = "a", ["\xc3\xa1"] = "a", ["\xc3\xa2"] = "a", ["\xc3\xa3"] = "a",
+    ["\xc3\xa4"] = "a", ["\xc3\xa5"] = "a", ["\xc3\xa6"] = "ae",
+    ["\xc3\xa7"] = "c",
+    ["\xc3\xa8"] = "e", ["\xc3\xa9"] = "e", ["\xc3\xaa"] = "e", ["\xc3\xab"] = "e",
+    ["\xc3\xac"] = "i", ["\xc3\xad"] = "i", ["\xc3\xae"] = "i", ["\xc3\xaf"] = "i",
+    ["\xc3\xb1"] = "n",
+    ["\xc3\xb2"] = "o", ["\xc3\xb3"] = "o", ["\xc3\xb4"] = "o", ["\xc3\xb5"] = "o",
+    ["\xc3\xb6"] = "o",
+    ["\xc3\xb9"] = "u", ["\xc3\xba"] = "u", ["\xc3\xbb"] = "u", ["\xc3\xbc"] = "u",
+    ["\xc3\xbd"] = "y", ["\xc3\xbf"] = "y",
+}
+
+local function normalize_accents(s)
+    for pattern, replacement in pairs(accent_map) do
+        s = s:gsub(pattern, replacement)
+    end
+    return s
+end
+
+-- Normalize a title for matching: lowercase, strip accents, strip trailing (...) and " - ..."
 local function bare(s)
     s = (s or ""):lower():match("^%s*(.-)%s*$")
+    -- Strip diacritics so "Kariênina" == "Karienina", "Tolstói" == "tolstoi", etc.
+    s = normalize_accents(s)
     s = s:gsub("%s*%b()%s*$", "")
     s = s:gsub("%s*%-%s*.+$", "")
     s = s:match("^%s*(.-)%s*$")
@@ -244,14 +281,25 @@ local keywords = {
     ["highlight"] = {
         "Highlight",
         "标注",
+        -- Portuguese (Kindle Brasil)
+        "destaque",
+        "Destaque",
     },
     ["note"] = {
         "Note",
         "笔记",
+        -- Portuguese
+        "nota",
+        "Nota",
+        "anotação",
+        "Anotação",
     },
     ["bookmark"] = {
         "Bookmark",
         "书签",
+        -- Portuguese
+        "marcador",
+        "Marcador",
     },
 }
 
@@ -267,7 +315,20 @@ local months = {
     ["Sep"] = 9,
     ["Oct"] = 10,
     ["Nov"] = 11,
-    ["Dec"] = 12
+    ["Dec"] = 12,
+    -- Portuguese month names (Kindle Brasil)
+    ["janeiro"]   = 1,
+    ["fevereiro"] = 2,
+    ["março"]     = 3,
+    ["abril"]     = 4,
+    ["maio"]      = 5,
+    ["junho"]     = 6,
+    ["julho"]     = 7,
+    ["agosto"]    = 8,
+    ["setembro"]  = 9,
+    ["outubro"]   = 10,
+    ["novembro"]  = 11,
+    ["dezembro"]  = 12,
 }
 
 local pms = {

--- a/utils/ParseClippings.lua
+++ b/utils/ParseClippings.lua
@@ -21,6 +21,89 @@ return function (instance)
 
     instance.targets = {}
 
+    -- If the user manually selected a source book via FilePick, use it directly.
+    if instance.manual_book and instance.manual_book ~= "" then
+        -- Cache so we don't re-parse on every tiny UI refresh
+        if instance._cached_file_path   == instance.file_path and
+           instance._cached_manual_book == instance.manual_book and
+           instance._cached_clippings   ~= nil then
+            -- reuse cached result (fall through to item collection below)
+        else
+            logger.dbg("HighlightImport: Using manual book selection → " .. instance.manual_book)
+            local all = instance.parser:parseFile(instance.file_path, "")
+            -- Keep only the manually selected title
+            for k in pairs(all) do
+                if k ~= instance.manual_book then all[k] = nil end
+            end
+            instance._cached_clippings   = all
+            instance._cached_file_path   = instance.file_path
+            instance._cached_manual_book = instance.manual_book
+        end
+
+        local clippings = instance._cached_clippings
+        if type(clippings) ~= "table" then return end
+
+        local all_items = {}
+        for title, booknotes in pairs(clippings) do
+            if type(booknotes) == "table" and #booknotes > 0 then
+                for _, entry in ipairs(booknotes) do
+                    if entry[1] and entry[1].text ~= "" then
+                        all_items[#all_items + 1] = {
+                            title = title,
+                            sort  = entry[1].sort,
+                            text  = entry[1].text,
+                            page  = entry[1].page,
+                            time  = entry[1].time,
+                        }
+                    end
+                end
+            end
+        end
+
+        local function get_page_num(page)
+            return tonumber(tostring(page or ""):match("^(%d+)")) or 0
+        end
+
+        local note_for_text = {}
+        for _, note_item in ipairs(all_items) do
+            if note_item.sort == "note" and note_item.time then
+                local best, best_diff = nil, math.huge
+                local note_page_num = get_page_num(note_item.page)
+                for _, h_item in ipairs(all_items) do
+                    if h_item.sort == "highlight"
+                        and h_item.title == note_item.title
+                        and get_page_num(h_item.page) == note_page_num
+                        and h_item.time then
+                        local diff = note_item.time - h_item.time
+                        if diff >= 0 and diff < best_diff then
+                            best_diff = diff
+                            best = h_item
+                        end
+                    end
+                end
+                if best then note_for_text[best.text] = note_item.text end
+            end
+        end
+
+        local seen = {}
+        for _, item in ipairs(all_items) do
+            if item.sort == "highlight" and not seen[item.text] then
+                seen[item.text] = true
+                instance.targets[#instance.targets + 1] = {
+                    annotation = item.text,
+                    note       = note_for_text[item.text],
+                    page       = item.page,
+                    status     = ITargetStatus.ADDED,
+                }
+            end
+        end
+
+        logger.dbg(string.format("HighlightImport: Parsed %d clippings (manual book).", #instance.targets))
+        return instance.targets
+    end
+
+    -- ── Automatic matching (no manual selection) ──────────────────────────────
+
     -- Determine the current book title for filtering
     local bare_current = ""
     if instance.ui and instance.ui.doc_props then
@@ -106,8 +189,9 @@ return function (instance)
             seen[item.text] = true
             instance.targets[#instance.targets + 1] = {
                 annotation = item.text,
-                note = note_for_text[item.text],
-                status = ITargetStatus.ADDED
+                note       = note_for_text[item.text],
+                page       = item.page,
+                status     = ITargetStatus.ADDED,
             }
         end
     end

--- a/views/FailedTargets.lua
+++ b/views/FailedTargets.lua
@@ -1,11 +1,48 @@
 local _ = require("gettext")
 local UIManager = require("ui/uimanager")
 local Modal = require("components.Modal")
+local Popup = require("components.Popup")
+local useCloseButton = require("composables.useCloseButton")
 
-function FailedTargetsView()
-    local modal = Modal(_("Failed targets"), {})
+--- Shows a scrollable list of highlights that failed to import.
+--- @param failed table  List of target objects with .annotation, .page, .note fields.
+return function(failed)
+    if not failed or #failed == 0 then return end
+
+    local ctx = {}
+
+    local entries = {}
+    for i, t in ipairs(failed) do
+        local page_str = tostring(t.page or "?")
+        local note_flag = t.note and " [note]" or ""
+        local label = string.format("[p.%s]%s %s", page_str, note_flag, t.annotation)
+        entries[#entries + 1] = {
+            text = label,
+            -- Tapping an entry shows its full text in a small popup.
+            callback = function()
+                local lines = {
+                    string.format(_("Page: %s"), page_str),
+                    "",
+                    t.annotation,
+                }
+                if t.note then
+                    lines[#lines + 1] = ""
+                    lines[#lines + 1] = _("Note:") .. " " .. t.note
+                end
+                local detail_ctx = {}
+                local detail = Popup(
+                    string.format(_("Failed highlight %d/%d"), i, #failed),
+                    table.concat(lines, "\n"),
+                    {{ text = _("Close"), callback = function() useCloseButton(detail_ctx) end }}
+                )
+                detail_ctx["parent"] = detail
+                UIManager:show(detail)
+            end,
+        }
+    end
+
+    local title = string.format(_("Failed highlights (%d)"), #failed)
+    local modal = Modal(title, entries)
+    ctx["parent"] = modal
     UIManager:show(modal)
-
 end
-
-return FailedTargetsView

--- a/views/FilePick.lua
+++ b/views/FilePick.lua
@@ -1,0 +1,126 @@
+local _ = require("gettext")
+local logger = require("logger")
+local UIManager = require("ui/uimanager")
+local MyClipping = require("services.MyClipping")
+local Modal = require("components.Modal")
+local ButtonTable = require("ui/widget/buttontable")
+local useCloseButton = require("composables.useCloseButton")
+local Alert = require("components.Alert")
+
+-- Parse the clippings file and return a sorted list of unique book titles.
+local function getAvailableBooks(file_path, parser)
+    if not file_path or file_path == "" then
+        return {}
+    end
+    local all_clippings = parser:parseFile(file_path, "")
+    local books = {}
+    for title, booknotes in pairs(all_clippings) do
+        -- only include books that actually have at least one highlight
+        local count = 0
+        if type(booknotes) == "table" then
+            for _, entry in ipairs(booknotes) do
+                if entry[1] and entry[1].text and entry[1].text ~= "" then
+                    count = count + 1
+                end
+            end
+        end
+        if count > 0 then
+            books[#books + 1] = { title = title, count = count }
+        end
+    end
+    table.sort(books, function(a, b) return a.title < b.title end)
+    return books
+end
+
+function FilePick(instance)
+    if not instance.file_path or instance.file_path == "" then
+        Alert(_("No clippings file selected. Please select a file first."))
+        return
+    end
+
+    local books = instance.available_books
+    if not books then
+        books = getAvailableBooks(instance.file_path, instance.parser)
+        instance.available_books = books
+    end
+
+    if #books == 0 then
+        Alert(_("No highlights found in the selected file."))
+        return
+    end
+
+    local ctx = {}
+
+    local function recreate(page)
+        if not page then page = 1 end
+
+        local modalEntries = {}
+        for _, book in ipairs(books) do
+            local selected = (instance.manual_book == book.title)
+            local prefix = selected and "[ * ] " or "[   ] "
+            local entry_title = book.title
+            modalEntries[#modalEntries + 1] = {
+                text = string.format("%s%s  (%d)", prefix, entry_title, book.count),
+                callback = function()
+                    if instance.manual_book == book.title then
+                        -- deselect: go back to automatic matching
+                        instance.manual_book = nil
+                        logger.dbg("HighlightImport: manual_book cleared (auto-match)")
+                    else
+                        instance.manual_book = book.title
+                        logger.dbg("HighlightImport: manual_book set → " .. book.title)
+                    end
+                    -- Invalidate cached parse result so next Import re-reads with new selection
+                    instance.targets = {}
+                    instance._cached_file_path   = nil
+                    instance._cached_manual_book = nil
+
+                    local pg = ctx["modalRef"] and ctx["modalRef"].page or 1
+                    UIManager:close(ctx["modalRef"])
+                    recreate(pg)
+                end,
+            }
+        end
+
+        -- Clear selection button
+        if instance.manual_book then
+            modalEntries[#modalEntries + 1] = {
+                text = _("[ Clear selection — use automatic matching ]"),
+                callback = function()
+                    instance.manual_book = nil
+                    instance.targets = {}
+                    instance._cached_file_path   = nil
+                    instance._cached_manual_book = nil
+                    logger.dbg("HighlightImport: manual_book cleared")
+                    UIManager:close(ctx["modalRef"])
+                    recreate(1)
+                end,
+            }
+        end
+
+        local buttonTable = ButtonTable:new{
+            buttons = {{
+                { text = _("Close"), callback = function() useCloseButton(ctx) end },
+            }}
+        }
+
+        local title_str = _("Select source book")
+        if instance.manual_book then
+            local short = instance.manual_book:sub(1, 40)
+            if #instance.manual_book > 40 then short = short .. "…" end
+            title_str = title_str .. ": " .. short
+        end
+
+        local modal = Modal(title_str, modalEntries, buttonTable)
+        ctx["modalRef"] = modal
+        ctx["parent"]   = modal
+
+        UIManager:show(modal)
+        modal:onGotoPage(page)
+        logger.dbg("HighlightImport: FilePick modal opened with " .. #books .. " books")
+    end
+
+    recreate()
+end
+
+return FilePick

--- a/views/Imports.lua
+++ b/views/Imports.lua
@@ -53,7 +53,7 @@ function ImportsView(instance)
     instance.targets = ParseClippings(instance)
     
     local matchingStrategy = MatchingStrategies:new{ instance = instance }
-    local strategyName = G_reader_settings:readSetting(("highlight_import_matching_algorithm"), "fuzzy")
+    local strategyName = G_reader_settings:readSetting(("highlight_import_matching_algorithm"), "adaptive")
     matchingStrategy:selectByName(strategyName)
 
     local function recreate(page)

--- a/views/Menu.lua
+++ b/views/Menu.lua
@@ -5,6 +5,7 @@ local AnnotationsView = require("views.annotations.Annotations")
 local FailedTargetsView = require("views.FailedTargets")
 local getSettings = require("views.settings.Settings")
 local fileSelector = require("components.fileSelector")
+local FilePick = require("views.FilePick")
 local Alert = require("components.Alert")
 local Popup = require("components.Popup")
 local useRecreateStatusPopup = require("composables/useRecreateStatusPopup")
@@ -24,6 +25,22 @@ function GetMenu(instance)
             -- keep_menu_open = true,
             callback = function()
                 fileSelector(instance)
+            end,
+        },
+        {
+            text_func = function()
+                if instance.file_path == "" then
+                    return _("Select source book")
+                end
+                if instance.manual_book then
+                    local short = instance.manual_book:sub(1, 30)
+                    if #instance.manual_book > 30 then short = short .. "…" end
+                    return _("Source book") .. ": " .. short
+                end
+                return _("Select source book") .. " (" .. _("auto") .. ")"
+            end,
+            callback = function()
+                FilePick(instance)
             end,
         },
         {

--- a/views/settings/Settings.lua
+++ b/views/settings/Settings.lua
@@ -14,7 +14,7 @@ function GetSettings(instance)
                     {name = "Legacy (exact)", provider = "exact_legacy", checked = false}, 
                     {name = "Adaptive search", provider = "adaptive", checked = false},
                 }
-                local strategyName = G_reader_settings:readSetting(("highlight_import_matching_algorithm"), "fuzzy")
+                local strategyName = G_reader_settings:readSetting(("highlight_import_matching_algorithm"), "adaptive")
 
                 for _, item in pairs(items) do
                     if item.provider == strategyName then


### PR DESCRIPTION
# HighlightImport — Pull Request: Improved matching & manual book selection

## Summary

This PR introduces four main improvements to the HighlightImport plugin for KOReader:

1. **Improved support for Portuguese (and other languages with special characters)**
2. **Adaptive search algorithm set as the new default**
3. **Failed imports summary screen**
4. **Manual source book selection from My Clippings.txt**

---

## 1. Portuguese (pt-BR) and multi-byte character support (`services/MatchingStrategies/adaptive.lua`)

### Problem
Highlights from books in Portuguese contained multi-byte characters (á, ã, ê, ç, —, etc.) that caused silent failures in KOReader's search engine. Lua's `string.sub` operates on bytes, and truncating a string in the middle of a multi-byte UTF-8 character produces invalid UTF-8 that the search engine silently rejects.

Additionally, Kindle books in Portuguese use a typographic em-dash (U+2014 `—`) for dialogue lines, while EPUB editions often omit the dash or encode it differently.

### Solution

#### `utf8_sub(s, max_bytes)`
New helper function that truncates strings at valid UTF-8 character boundaries, ensuring the prefix sent to the search engine is always valid UTF-8. Replaces all uses of `string.sub(s, 1, N)` in the adaptive algorithm.

#### `strip_dashes(s)`
New helper function that removes em/en-dashes (`—`/`–`) and surrounding spaces, producing a "clean" version of the text for search retries when the clipping contains a typographic dash but the EPUB does not.

#### New search fallbacks (in order of attempt)
| Fallback | Description |
|---|---|
| `strip-dashes` | Removes dashes and retries (forward + backward + 80/50-byte prefixes) |
| `around-dash` | Searches the text segment at/after the first dash, with and without the dash character |
| `norm-dash` | Normalized version (em-dash → ` - `) of the post-dash segment |
| `newline-split` | Splits multi-paragraph highlights by `\n` and searches each line independently |
| `first-sentence` | Extracts the first complete sentence (up to `.`, `!`, `?`) and searches for it |

The `newline-split` fallback resolves the most common failure case: highlights that span paragraphs on Kindle are stored with a literal `\n`, but KOReader's search engine only matches within a single EPUB paragraph element.

---

## 2. Adaptive algorithm set as default (`main.lua`, `views/Imports.lua`, `views/settings/Settings.lua`)

### Change
The default matching algorithm was changed from `"fuzzy"` to `"adaptive"` in all configuration points:

- `main.lua`: plugin initialization
- `views/Imports.lua`: strategy selection in the import view
- `views/settings/Settings.lua`: algorithm selection in the settings screen

The adaptive algorithm is more robust and includes multiple fallbacks, making it preferable over fuzzy for any language.

---

## 3. Failed imports summary screen (`views/FailedTargets.lua`, `components/StatusPopup.lua`)

### Problem
After an import, the user could see how many highlights had failed, but had no way to review which ones.

### Solution

#### `views/FailedTargets.lua` (fully implemented)
The view was completely implemented (it was previously empty). It now displays a scrollable list of all failed highlights, showing the page number and a text excerpt. Tapping an entry opens a popup with the full annotation text (and note, if present).

#### `components/StatusPopup.lua`
When an import finishes with failures, the status popup now shows a **"View failed (N)"** button that opens the `FailedTargets` screen directly.

---

## 4. Manual source book selection (`views/FilePick.lua`, `views/Menu.lua`)

### Problem
The plugin tried to match the title of the book open in KOReader against titles inside `My Clippings.txt`. When the titles differed (different edition, localized title, abbreviation), no highlights were found at all.

### Solution

#### `views/FilePick.lua` (new file)
New view that:
- Reads the `My Clippings.txt` file and lists all books that have at least one highlight
- Displays the highlight count per book
- Allows manually selecting a book (marked with `[ * ]`)
- Allows deselecting (reverting to automatic title-based matching)
- Invalidates the parse cache when the selection changes

The manual selection is stored in `instance.manual_book` and used by `ParseClippings` to filter highlights from the correct book.

#### `views/Menu.lua`
A new **"Select source book"** menu item was added between "Select file" and "Import". The label shows:
- `"Select source book (auto)"` — when no manual selection is active
- `"Source book: <truncated title>"` — when a book is manually selected

---

## Modified files

| File | Change type |
|---|---|
| `services/MatchingStrategies/adaptive.lua` | Modified — UTF-8 safe truncation + pt-BR fallbacks |
| `main.lua` | Modified — default algorithm `fuzzy` → `adaptive` |
| `views/Imports.lua` | Modified — default algorithm `fuzzy` → `adaptive` |
| `views/settings/Settings.lua` | Modified — default algorithm `fuzzy` → `adaptive` |
| `components/StatusPopup.lua` | Modified — "View failed" button when failures exist |
| `views/FailedTargets.lua` | Modified — full implementation (was empty) |
| `views/FilePick.lua` | **New** — manual source book selection |
| `views/Menu.lua` | Modified — new "Select source book" menu item |

---

## Compatibility

- Fully backward compatible: automatic title-based matching continues to work as the default
- Manual selection is optional and can be cleared at any time
- The `fuzzy` and `exact_legacy` algorithms remain available in settings
- No data migration required
